### PR TITLE
[CHORE]Disable staging deployment notifications

### DIFF
--- a/.github/workflows/deployment-notification.yml
+++ b/.github/workflows/deployment-notification.yml
@@ -35,8 +35,3 @@ jobs:
             -H "Authorization: ${{ secrets.LAMBDA_DEPLOYMENT_TO_SLACK_NOTIFICATIONS_AUTHORIZATION }}" \
             -X POST \
             ${{ secrets.LAMBDA_DEPLOYMENT_TO_SLACK_NOTIFICATIONS_PRODUCTION_URL }}
-          curl -s -d "$JSON_PAYLOAD" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: ${{ secrets.LAMBDA_DEPLOYMENT_TO_SLACK_NOTIFICATIONS_AUTHORIZATION }}" \
-            -X POST \
-            ${{ secrets.LAMBDA_DEPLOYMENT_TO_SLACK_NOTIFICATIONS_STAGING_URL }}


### PR DESCRIPTION
Since we released the lambda to the latest version, we don't need anymore to test the staging stage of the lambda.
