### PR TITLE
[CHORE]Add semver related workflows

### DIFF
--- a/.github/workflows/semver-label-checker.yml
+++ b/.github/workflows/semver-label-checker.yml
@@ -1,0 +1,13 @@
+name: Semver label checker
+on:
+  workflow_call:
+
+jobs:
+  semver-label-check:
+    name: Check semver label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://agilepathway/pull-request-label-checker:v1.4.25
+        with:
+          one_of: major,minor,patch
+          repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag-semver-release.yml
+++ b/.github/workflows/tag-semver-release.yml
@@ -1,0 +1,16 @@
+name: Semver tag release
+on:
+  workflow_call:
+
+jobs:
+  semver-tag-release:
+    if: github.base_ref == 'main' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tag release
+        uses: K-Phoen/semver-release-action@v1.3.2
+        with:
+          release_branch: main
+          release_strategy: tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Create 2 reusable workflows:
- `semver-label-checker`
  - Allows to check that one of the `major`, `minor` or `patch` label is applyied on a PR.
- `tag-semver-release`
  - Tag `main` branch with a bumped semver. Depending on the label of the merged PR. 
